### PR TITLE
Add new maps and custom config path

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 -- vim.cmd('set rtp+=~/.config/nvcode')
 if vim.g.vscode then
-  vim.cmd('source ~/.config/nvim/vimscript/nv-vscode/init.vim')
+  vim.cmd("source " .. vim.fn.stdpath("config") .. "/vimscript/nv-vscode/init.vim")
   require('settings')
   require('nv-quickscope')
 else
@@ -38,8 +38,8 @@ else
   require('nv-dial')
 
   -- Which Key (Hope to replace with Lua plugin someday)
-  vim.cmd('source ~/.config/nvim/vimscript/nv-whichkey/init.vim')
-  vim.cmd('source ~/.config/nvim/vimscript/functions.vim')
+  vim.cmd("source " .. vim.fn.stdpath("config") .. "/vimscript/nv-whichkey/init.vim")
+  vim.cmd("source " .. vim.fn.stdpath("config") .. "/vimscript/functions.vim")
 
   -- LSP
   require('lsp')

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -56,7 +56,6 @@ vim.api.nvim_set_keymap('x', 'J', ':move \'>+1<CR>gv-gv', {noremap = true, silen
 -- Alternative ways
 vim.api.nvim_set_keymap('n', '<C-s>', ':w<CR>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('n', '<C-q>', ':q!<CR>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<C-c>', '<Esc>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('n', '<C-w>', ':bdelete<CR>', { noremap = true, silent = true })
 
 

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -53,6 +53,13 @@ vim.api.nvim_set_keymap('n', '<S-TAB>', ':bprevious<CR>', {noremap = true, silen
 vim.api.nvim_set_keymap('x', 'K', ':move \'<-2<CR>gv-gv', {noremap = true, silent = true})
 vim.api.nvim_set_keymap('x', 'J', ':move \'>+1<CR>gv-gv', {noremap = true, silent = true})
 
+-- Alternative ways
+vim.api.nvim_set_keymap('n', '<C-s>', ':w<CR>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<C-q>', ':q!<CR>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<C-c>', '<Esc>', { noremap = true, silent = true })
+vim.api.nvim_set_keymap('n', '<C-w>', ':bdelete<CR>', { noremap = true, silent = true })
+
+
 -- Better nav for omnicomplete
 vim.cmd('inoremap <expr> <c-j> (\"\\<C-n>\")')
 vim.cmd('inoremap <expr> <c-k> (\"\\<C-p>\")')


### PR DESCRIPTION
Add keymaps to exit without saving, save and delete buffer.
also use a custom path for the configuration in case it is not found in ~/.config/nvim in my case the configuration is found in another folder and I configure it with $XDG_CONFIG_HOME