### PR TITLE
[LSP] clangd - Add support for C/C++ with clangd.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -42,6 +42,7 @@ vim.cmd('source ~/.config/nvim/vimscript/functions.vim')
 
 -- LSP
 require('lsp')
+require('lsp.clangd')
 require('lsp.lua-ls')
 require('lsp.bash-ls')
 require('lsp.js-ts-ls')

--- a/lua/lsp/clangd.lua
+++ b/lua/lsp/clangd.lua
@@ -1,0 +1,3 @@
+require'lspconfig'.clangd.setup{
+    on_attach = require'lsp'.common_on_attach
+}


### PR DESCRIPTION
I'm using this as my daily driver for C/C++ LSP.
It expects to find a compile-commands.json file in your root project folder.

It also picks up extra project specific settings from a .clangd file as described by the clangd docs.