### PR TITLE
[LSP] clangd - Support LspInstall upstream path.

### DIFF
--- a/lua/lsp/clangd.lua
+++ b/lua/lsp/clangd.lua
@@ -1,4 +1,4 @@
 require'lspconfig'.clangd.setup{
-    cmd = {DATA_PATH .. "/lspinstall/clangd/clangd_11.0.0/bin/clangd"},
+    cmd = {DATA_PATH .. "/lspinstall/cpp/clangd/bin/clangd"},
     on_attach = require'lsp'.common_on_attach
 }


### PR DESCRIPTION
No that LspInstall have landed the clangd support, they have improved it to support future versions of clangd automatically.
