### PR TITLE
Refactor telescope extension config

### DIFF
--- a/lua/nv-telescope/init.lua
+++ b/lua/nv-telescope/init.lua
@@ -62,14 +62,12 @@ require('telescope').setup {
             }
         }
     },
-    require'telescope'.setup {
-        extensions = {
-            media_files = {
-                -- filetypes whitelist
-                -- defaults to {"png", "jpg", "mp4", "webm", "pdf"}
-                filetypes = {"png", "webp", "jpg", "jpeg"},
-                find_cmd = "rg" -- find command (defaults to `fd`)
-            }
+    extensions = {
+        media_files = {
+            -- filetypes whitelist
+            -- defaults to {"png", "jpg", "mp4", "webm", "pdf"}
+            filetypes = {"png", "webp", "jpg", "jpeg"},
+            find_cmd = "rg" -- find command (defaults to `fd`)
         }
     }
 }


### PR DESCRIPTION
Desired way to configure extensions is
to put it at the same level as 'defaults' property inside the 'setup' call.