### PR TITLE
Add display name for key ' '(<Space>) in whichkey

### DIFF
--- a/vimscript/nv-whichkey/init.vim
+++ b/vimscript/nv-whichkey/init.vim
@@ -3,7 +3,7 @@
 " Timeout
 let g:which_key_timeout = 100
 
-let g:which_key_display_names = {'<CR>': '↵', '<TAB>': '⇆'}
+let g:which_key_display_names = {'<CR>': '↵', '<TAB>': '⇆', " ": 'SPC'}
 
 " Map leader to which_key
 nnoremap <silent> <leader> :silent <c-u> :silent WhichKey '<Space>'<CR>


### PR DESCRIPTION
Key for ' '(<Space>) is displayed on the panel as 'SPC' by default.
However, it is displayed as blank instead of 'SPC'
when assigning 'which_key_display_names' variable without specifiying it.