### PR TITLE
Add inccommand=split to settings

### DIFF
--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -1,5 +1,6 @@
 vim.cmd('set iskeyword+=-') -- treat dash separated words as a word text object"
 vim.cmd('set shortmess+=c') -- Don't pass messages to |ins-completion-menu|.
+vim.cmd('set inccommand=split') -- Make substitution work in realtime
 vim.o.hidden = true -- Required to keep multiple buffers open multiple buffers
 vim.wo.wrap = false -- Display long lines as just one line
 vim.cmd('set whichwrap+=<,>,[,],h,l') -- move to next line with theses keys


### PR DESCRIPTION
This allows `:s///` or `:%s///` or `:'<,'>s///` commands to work in realtime.

How it works (video is not mine): [video](https://www.youtube.com/watch?v=dY9dME3l-iQ)

The bottom split can be ommited by passing `nosplit` instead of `split`.