### PR TITLE
Add more space between icon and description in dashboard

### DIFF
--- a/lua/nv-dashboard/init.lua
+++ b/lua/nv-dashboard/init.lua
@@ -10,12 +10,12 @@ vim.g.dashboard_custom_header = {
 vim.g.dashboard_default_executive = 'telescope'
 
 vim.g.dashboard_custom_section = {
-    a = {description = {' Find File          '}, command = 'Telescope find_files'},
-    b = {description = {' Recently Used Files'}, command = 'Telescope oldfiles'},
-    c = {description = {' Load Last Session  '}, command = 'SessionLoad'},
-    d = {description = {' Find Word          '}, command = 'Telescope live_grep'},
-    e = {description = {' Settings           '}, command = ':e ~/.config/nvim/nv-settings.lua'}
-    -- e = {description = {' Marks              '}, command = 'Telescope marks'}
+    a = {description = {'  Find File          '}, command = 'Telescope find_files'},
+    b = {description = {'  Recently Used Files'}, command = 'Telescope oldfiles'},
+    c = {description = {'  Load Last Session  '}, command = 'SessionLoad'},
+    d = {description = {'  Find Word          '}, command = 'Telescope live_grep'},
+    e = {description = {'  Settings           '}, command = ':e ~/.config/nvim/nv-settings.lua'}
+    -- e = {description = {'  Marks              '}, command = 'Telescope marks'}
 }
 
 -- file_browser = {description = {' File Browser'}, command = 'Telescope find_files'},


### PR DESCRIPTION
Only small thing, but it looks nicer and less cluttered.

Before:
![Before](https://user-images.githubusercontent.com/30533306/113361716-daa55d00-934c-11eb-88c8-374a8ea7e2a9.png)

After:
![After](https://user-images.githubusercontent.com/30533306/113361751-ef81f080-934c-11eb-983d-cb7b9f60e859.png)