### PR TITLE
Add bindings to quickly quit certain buffers

### DIFF
--- a/lua/nv-autocommands/init.lua
+++ b/lua/nv-autocommands/init.lua
@@ -44,5 +44,10 @@ utils.define_augroups({
         {'BufWinEnter', '.sol', 'setlocal filetype=solidity'}, {'BufRead', '*.sol', 'setlocal filetype=solidity'},
         {'BufNewFile', '*.sol', 'setlocal filetype=solidity'}
     },
+    _buffer_bindings = {
+        {'FileType', 'dashboard', 'nnoremap <silent> <buffer> q :q<CR>'},
+        {'FileType', 'lspinfo', 'nnoremap <silent> <buffer> q :q<CR>'},
+        {'FileType', 'floaterm', 'nnoremap <silent> <buffer> q :q<CR>'}
+    },
     _auto_formatters = auto_formatters
 })


### PR DESCRIPTION
I added bindings for `dashboard`, `lspinfo`, and `floaterm` to quickly quit out of them with `q` key.
The `<buffer>` thing scopes keybind to buffer of given filetype only.

This is inspired by `startify` plugin becouse these plugins doesn't have way to set bindings like that.

In floaterm you have to first hit `<Esc>` then `q`.