### PR TITLE
Fix opening settings from dashboard

### DIFF
--- a/lua/nv-autocommands/init.lua
+++ b/lua/nv-autocommands/init.lua
@@ -37,7 +37,7 @@ utils.define_augroups({
         {
             'FileType', 'dashboard',
             'setlocal nocursorline noswapfile synmaxcol& signcolumn=no norelativenumber nocursorcolumn nospell  nolist  nonumber bufhidden=wipe colorcolumn= foldcolumn=0 matchpairs= '
-        }, {'FileType', 'dashboard', 'set showtabline=0 | autocmd WinLeave <buffer> set showtabline=2'}
+        }, {'FileType', 'dashboard', 'set showtabline=0 | autocmd BufLeave <buffer> set showtabline=2'}
     },
     _markdown = {{'FileType', 'markdown', 'setlocal wrap'}, {'FileType', 'markdown', 'setlocal spell'}},
     _solidity = {


### PR DESCRIPTION
Previously the tabline wouldn't show up after opening `Settings` from dashboard.