### PR TITLE
Make tsserver work on standalone files

### DIFF
--- a/lua/lsp/js-ts-ls.lua
+++ b/lua/lsp/js-ts-ls.lua
@@ -14,7 +14,7 @@ require'lspconfig'.tsserver.setup {
     on_attach = require'lsp'.tsserver_on_attach,
     -- This makes sure tsserver is not used for formatting (I prefer prettier)
     -- on_attach = require'lsp'.common_on_attach,
-    root_dir = require('lspconfig/util').root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git"),
+    root_dir = require('lspconfig/util').root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git", "."),
     settings = {documentFormatting = false},
     handlers = {
         ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {


### PR DESCRIPTION
This patch allows tsserver to activate on standalone files, by adding `.`, as a `root_dir` marker.

This shouldn't break working inside projects, becouse now tsserver will behave like vscode's integrated server.