### PR TITLE
load plugin configs via packer

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -8,7 +8,7 @@ require('nv-autocommands')
 require('settings')
 require('keymappings')
 require('colorscheme')
-require('nv-galaxyline')
+-- require('nv-galaxyline')
 
 -- Plugins
 require('nv-compe')

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -9,6 +9,8 @@ if fn.empty(fn.glob(install_path)) > 0 then
     execute 'packadd packer.nvim'
 end
 
+local my = function(file) require(file) end
+
 vim.cmd 'autocmd BufWritePost plugins.lua PackerCompile' -- Auto compile when there are changes in plugins.lua
 
 -- require('packer').init({display = {non_interactive = true}})
@@ -55,7 +57,8 @@ return require('packer').startup(function(use)
     use 'ryanoasis/vim-devicons'
 
     -- Status Line and Bufferline
-    use 'glepnir/galaxyline.nvim'
+    use { 'glepnir/galaxyline.nvim', config = my('nv-galaxyline') }
+    -- use { 'glepnir/galaxyline.nvim', config = function() require'nv-galaxyline' end } -- inline fn alternative
     use 'romgrk/barbar.nvim'
 
     -- Telescope


### PR DESCRIPTION
example of loading specific plugin configs via packer
cleans up init.lua
allows for disabling plugin and its config by commenting out one line