### PR TITLE
Add vim-vinegar style mapping for Ranger

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -6,6 +6,7 @@ vim.api.nvim_set_keymap('n', '<Leader>h', ':set hlsearch!<CR>', {noremap = true,
 
 -- explorer
 vim.api.nvim_set_keymap('n', '<Leader>e', ':NvimTreeToggle<CR>', {noremap = true, silent = true})
+vim.api.nvim_set_keymap('n', '-', ':RnvimrToggle<CR>', {noremap = true, silent = true})
 
 -- better window movement
 vim.api.nvim_set_keymap('n', '<C-h>', '<C-w>h', {silent = true})


### PR DESCRIPTION
Adds a vim-vinegar style mapping ('-' in normal mode) for accessing ranger.