### PR TITLE
minor-installer-fix: remove install argument from pacman

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -109,7 +109,7 @@ installonubuntu() {
 }
 
 installonarch() {
-	sudo pacman -S install ripgrep fzf ranger
+	sudo pacman -S ripgrep fzf ranger
 	which yay >/dev/null && yay -S python-ueberzug-git || pipinstallueberzug
 	pip3 install neovim-remote
 	npm install -g tree-sitter-cli


### PR DESCRIPTION
I also mentioned adding `sudo` to `npm i -g`, but you actually would not want to do this. The reason I was getting the error is because I had installed nvm, but hadn't set it up on my fresh install yet.