### PR TITLE
Change vimgrep_arguments to find_command

### DIFF
--- a/lua/nv-telescope/init.lua
+++ b/lua/nv-telescope/init.lua
@@ -5,7 +5,7 @@ local actions = require('telescope.actions')
 require('telescope').load_extension('media_files')
 require('telescope').setup {
     defaults = {
-        vimgrep_arguments = {'rg', '--no-heading', '--with-filename', '--line-number', '--column', '--smart-case'},
+        find_command = {'rg', '--no-heading', '--with-filename', '--line-number', '--column', '--smart-case'},
         prompt_position = "top",
         prompt_prefix = " ",
         selection_caret = " ",


### PR DESCRIPTION
This option was marked as TODO in the telescope-nvim readme. This may be a suitable replacement in the meantime.