### PR TITLE
Add a fallback for "ensurepip" on Debian based distros

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -170,9 +170,11 @@ function install_nodejs_deps() {
 
 function install_python_deps() {
   echo "Verifying that pip is available.."
-  if ! pip3 --version &>/dev/null; then
-    print_missing_dep_msg "pip"
-    exit 1
+  if ! python3 -m ensurepip &>/dev/null; then
+    if ! command -v pip3 &>/dev/null; then
+      print_missing_dep_msg "pip"
+      exit 1
+    fi
   fi
   echo "Installing with pip.."
   for dep in "${__pip_deps[@]}"; do


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
In the installer script, we use the command below in order to check if pip is installed.
`python3 -m ensurepip`
But ensurepip is disabled in Debian/Ubuntu for the system python.
So a better choice could be just using:
`pip3 --version`

Fixes Install script failing to check for pip in Debian based distros.

## How Has This Been Tested?
Tested by running successfully the script with the according check.

- Run command `./install.sh`
- Check logs