### PR TITLE
[Feature] Fetch from git before update in install script

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -274,7 +274,7 @@ function setup_lvim() {
 
 function update_lvim() {
   git -C "$LUNARVIM_RUNTIME_DIR/lvim" fetch --quiet
-  if ! git -C "$LUNARVIM_RUNTIME_DIR/lvim" diff --quiet @{u}; then
+  if ! git -C "$LUNARVIM_RUNTIME_DIR/lvim" diff --quiet "@{upstream}"; then
     git -C "$LUNARVIM_RUNTIME_DIR/lvim" merge --ff-only --progress ||
       echo "Unable to guarantee data integrity while updating. Please do that manually instead." && exit 1
   fi


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

When running the install script after installation, fetch the latest from git before
checking if there are updates.

This also avoids backing up the .git directory of the
previous installation.

## How Has This Been Tested?

I ran it locally to test

- Run command `./utils/installers/install.sh`

