### PR TITLE
feat(lsp): handle user configuration in setup()

### DIFF
--- a/lua/core/commands.lua
+++ b/lua/core/commands.lua
@@ -11,8 +11,8 @@ M.defaults = {
   endfunction
   ]],
   -- :LvimInfo
-  [[command! LvimInfo lua require('core.info').toggle_popup(vim.bo.filetype)]],
-  [[ command! LvimCacheReset lua require('bootstrap').reset_cache() ]],
+  [[ command! LvimInfo lua require('core.info').toggle_popup(vim.bo.filetype) ]],
+  [[ command! LvimCacheReset lua require('utils.hooks').reset_cache() ]],
   [[ command! LvimUpdate lua require('bootstrap').update() ]],
 }
 

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -125,6 +125,7 @@ function M.setup()
   for _, sign in ipairs(lvim.lsp.diagnostics.signs.values) do
     vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = sign.name })
   end
+
   require("lsp.handlers").setup()
 
   if not utils.is_directory(lvim.lsp.templates_dir) then

--- a/lua/lsp/templates.lua
+++ b/lua/lsp/templates.lua
@@ -23,7 +23,7 @@ function M.is_ignored(server_name, filetypes)
   filetypes = filetypes or get_supported_filetypes(server_name)
 
   if vim.tbl_contains(filetypes, "javascript") then
-    if server_name == "tsserver" or server_name == "tailwindcss" then
+    if server_name == "tsserver" then
       return false
     else
       return true

--- a/lua/utils/hooks.lua
+++ b/lua/utils/hooks.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+local Log = require "core.log"
+local in_headless = #vim.api.nvim_list_uis() == 0
+
+function M.run_pre_update()
+  Log:debug "Starting pre-update hook"
+end
+
+---Reset any startup cache files used by Packer and Impatient
+---Tip: Useful for clearing any outdated settings
+function M.reset_cache()
+  _G.__luacache.clear_cache()
+  require("plugin-loader"):cache_reset()
+end
+
+function M.run_post_update()
+  M.reset_cache()
+  Log:debug "Starting post-update hook"
+  package.loaded["lsp.templates"] = nil
+  require("lsp.templates").generate_templates()
+
+  if not in_headless then
+    vim.schedule(function()
+      require("packer").install()
+      -- TODO: add a changelog
+      vim.notify("Update complete", vim.log.levels.INFO)
+      vim.cmd "LspStart"
+    end)
+  end
+end
+
+return M

--- a/tests/lsp_spec.lua
+++ b/tests/lsp_spec.lua
@@ -79,7 +79,6 @@ a.describe("lsp workflow", function()
     local ts_template = utils.join_paths(lvim.lsp.templates_dir, "typescript.lua")
 
     assert.True(utils.file_contains(ts_template, "tsserver"))
-    assert.True(utils.file_contains(ts_template, "tailwindcss"))
     assert.False(utils.file_contains(ts_template, test_server.name))
   end)
 


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- allow passing user configuration directly when calling `require('lsp.manager').setup("myserver", myopts)`. 
These options will take precedence over any pre-existing default configuration.
- allow calling the setup function for servers not supported yet by "nvim-lsp-installer"

Fixes #1697

## How Has This Been Tested?

You can try this simple test

```lua
lvim.lsp.on_init_callback = function ()
  print("hello")
end

require("lsp.manager").setup("stylelint_lsp", {
	on_attach = function()
		print("world")
	end,
})
```

You can also test a server that's not supported by "nvim-lsp-installer"
