### PR TITLE
fix: register null-ls providers per filetype

### DIFF
--- a/lua/lsp/null-ls/formatters.lua
+++ b/lua/lsp/null-ls/formatters.lua
@@ -23,7 +23,7 @@ function M.list_available(filetype)
   return formatters
 end
 
-function M.list_configured(formatter_configs)
+function M.list_configured(formatter_configs, filetype)
   local formatters, errors = {}, {}
 
   for _, fmt_config in ipairs(formatter_configs) do
@@ -39,7 +39,11 @@ function M.list_configured(formatter_configs)
         errors[fmt_config.exe] = {} -- Add data here when necessary
       else
         Log:debug("Using formatter: " .. formatter_cmd)
-        formatters[fmt_config.exe] = formatter.with { command = formatter_cmd, extra_args = fmt_config.args }
+        formatters[fmt_config.exe] = formatter.with {
+          command = formatter_cmd,
+          extra_args = fmt_config.args,
+          filetypes = { filetype },
+        }
       end
     end
   end
@@ -52,9 +56,8 @@ function M.setup(formatter_configs, filetype)
     return
   end
 
-  local formatters_by_ft = {}
-  formatters_by_ft[filetype] = M.list_configured(formatter_configs)
-  null_ls.register { sources = formatters_by_ft[filetype].supported }
+  local formatters_by_ft = M.list_configured(formatter_configs, filetype)
+  null_ls.register { sources = formatters_by_ft.supported }
 end
 
 return M

--- a/lua/lsp/null-ls/init.lua
+++ b/lua/lsp/null-ls/init.lua
@@ -13,12 +13,12 @@ function M:setup()
 
   null_ls.config()
   require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
-  for _, filetype in pairs(lvim.lang) do
-    if filetype.formatters then
-      formatters.setup(filetype.formatters, filetype)
+  for filetype, config in pairs(lvim.lang) do
+    if not vim.tbl_isempty(config.formatters) then
+      formatters.setup(config.formatters, filetype)
     end
-    if filetype.linters then
-      linters.setup(filetype.linters, filetype)
+    if not vim.tbl_isempty(config.linters) then
+      linters.setup(config.linters, filetype)
     end
   end
 end

--- a/lua/lsp/null-ls/linters.lua
+++ b/lua/lsp/null-ls/linters.lua
@@ -23,7 +23,7 @@ function M.list_available(filetype)
   return linters
 end
 
-function M.list_configured(linter_configs)
+function M.list_configured(linter_configs, filetype)
   local linters, errors = {}, {}
 
   for _, lnt_config in pairs(linter_configs) do
@@ -39,7 +39,11 @@ function M.list_configured(linter_configs)
         errors[lnt_config.exe] = {} -- Add data here when necessary
       else
         Log:debug("Using linter: " .. linter_cmd)
-        linters[lnt_config.exe] = linter.with { command = linter_cmd, extra_args = lnt_config.args }
+        linters[lnt_config.exe] = linter.with {
+          command = linter_cmd,
+          extra_args = lnt_config.args,
+          filetypes = { filetype },
+        }
       end
     end
   end
@@ -52,9 +56,8 @@ function M.setup(linter_configs, filetype)
     return
   end
 
-  local linters_by_ft = {}
-  linters_by_ft[filetype] = M.list_configured(linter_configs)
-  null_ls.register { sources = linters_by_ft[filetype].supported }
+  local linters_by_ft = M.list_configured(linter_configs, filetype)
+  null_ls.register { sources = linters_by_ft.supported }
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Register null-ls providers by filetype. This prevents providers such as `prettier` from attaching to any filetype other than the requested one.

Fixes #1706

## How Has This Been Tested?

Adding this will only get `prettier` to be attached to javascript files and not any other type.

```lua
lvim.lang.javascript.formatters = { { exe = "prettier" } }
```
