### PR TITLE
fix: correct variable names in NvimTree setup table

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -6,9 +6,9 @@ function M.config()
     active = true,
     on_config_done = nil,
     setup = {
-      auto_open = 0,
+      open_on_setup = 0,
       auto_close = 1,
-      tab_open = 0,
+      open_on_tab = 0,
       update_focused_file = {
         enable = 1,
       },


### PR DESCRIPTION
# Description
While migrating to the new setup method, NvimTree changed the name of these variables as can be seen here: https://github.com/kyazdani42/nvim-tree.lua/issues/674, and in the updated vim documentation.