### PR TITLE
fix(telescope): prompt position when find/grep LunarVim files

### DIFF
--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -26,7 +26,6 @@ function M.config()
       layout_strategy = "horizontal",
       layout_config = {
         width = 0.75,
-        prompt_position = "bottom",
         preview_cutoff = 120,
         horizontal = { mirror = false },
         vertical = { mirror = false },
@@ -91,9 +90,6 @@ function M.find_lunarvim_files(opts)
   local theme_opts = themes.get_ivy {
     sorting_strategy = "ascending",
     layout_strategy = "bottom_pane",
-    layout_config = {
-      prompt_position = "top",
-    },
     prompt_prefix = ">> ",
     prompt_title = "~ LunarVim files ~",
     cwd = utils.join_paths(get_runtime_dir(), "lvim"),
@@ -109,9 +105,6 @@ function M.grep_lunarvim_files(opts)
   local theme_opts = themes.get_ivy {
     sorting_strategy = "ascending",
     layout_strategy = "bottom_pane",
-    layout_config = {
-      prompt_position = "top",
-    },
     prompt_prefix = ">> ",
     prompt_title = "~ search LunarVim ~",
     cwd = utils.join_paths(get_runtime_dir(), "lvim"),


### PR DESCRIPTION
# Description

With this [commit](https://github.com/nvim-telescope/telescope.nvim/commit/be600b5421c652c84f94c0c75ba6d309165ed0ef) from `telescope.nvim`, `prompt_position` is provided for `bottom_pane` and `vertical` layout strategy.
~~In order to keep `prompt` in the upper place, we should set this key explicitly in LunarVim.~~
In order to keep `prompt` in the upper place, we should remove this key in LunarVim's default layout and just let every layout strategy use their default prompt position.
