### PR TITLE
fix: don't use the cmp floating window

### DIFF
--- a/lua/core/cmp.lua
+++ b/lua/core/cmp.lua
@@ -34,6 +34,10 @@ M.config = function()
       behavior = cmp.ConfirmBehavior.Replace,
       select = true,
     },
+    experimental = {
+      ghost_text = false,
+      native_menu = true,
+    },
     formatting = {
       kind_icons = {
         Class = " ",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Don't use the nvim-cmp floating window till we figure it the required migration
Fixes #1714

@carvhal can you test if this fixes your issue?