### PR TITLE
[Refactor] Make preselect behavior configurable

### DIFF
--- a/lua/core/cmp.lua
+++ b/lua/core/cmp.lua
@@ -106,13 +106,15 @@ M.config = function()
       { name = "treesitter" },
       { name = "crates" },
     },
+    ---@usage enable or disable preselection of autocompletion results when tabbing
+    preselect = true,
     mapping = {
       ["<C-d>"] = cmp.mapping.scroll_docs(-4),
       ["<C-f>"] = cmp.mapping.scroll_docs(4),
       -- TODO: potentially fix emmet nonsense
       ["<Tab>"] = cmp.mapping(function()
         if vim.fn.pumvisible() == 1 then
-          vim.fn.feedkeys(T "<down>", "n")
+          vim.fn.feedkeys(T(lvim.builtin.cmp.preselect and "<C-n>" or "<down>"), "n")
         elseif luasnip.expand_or_jumpable() then
           vim.fn.feedkeys(T "<Plug>luasnip-expand-or-jump", "")
         elseif check_backspace() then
@@ -128,7 +130,7 @@ M.config = function()
       }),
       ["<S-Tab>"] = cmp.mapping(function(fallback)
         if vim.fn.pumvisible() == 1 then
-          vim.fn.feedkeys(T "<up>", "n")
+          vim.fn.feedkeys(T(lvim.builtin.cmp.preselect and "<C-p>" or "<up>"), "n")
         elseif luasnip.jumpable(-1) then
           vim.fn.feedkeys(T "<Plug>luasnip-jump-prev", "")
         else


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This makes the preselection behavior for auto-completion configurable. 

This *does not* address changes from f0b30f0 in keymappings.lua. Does it make sense for LunarVim to use `lvim.builtin.cmp.preselect` in that file?

Also, does this need to be documented anywhere?

Fixes #1716

## How Has This Been Tested?

I used this locally and confirmed it works. To repro, try typing something that's autocompletable, and then tabbing through the results.