### PR TITLE
feat(cmp): make popupmenu formatting options configurable

### DIFF
--- a/lua/core/cmp.lua
+++ b/lua/core/cmp.lua
@@ -66,23 +66,27 @@ M.config = function()
         Value = " ",
         Variable = " ",
       },
+      source_names = {
+        nvim_lsp = "(LSP)",
+        emoji = "(Emoji)",
+        path = "(Path)",
+        calc = "(Calc)",
+        cmp_tabnine = "(Tabnine)",
+        vsnip = "(Snippet)",
+        luasnip = "(Snippet)",
+        buffer = "(Buffer)",
+      },
+      duplicates = {
+        buffer = 1,
+        path = 1,
+        nvim_lsp = 0,
+      },
+      duplicates_default = 0,
       format = function(entry, vim_item)
         vim_item.kind = lvim.builtin.cmp.formatting.kind_icons[vim_item.kind]
-        vim_item.menu = ({
-          nvim_lsp = "(LSP)",
-          emoji = "(Emoji)",
-          path = "(Path)",
-          calc = "(Calc)",
-          cmp_tabnine = "(Tabnine)",
-          vsnip = "(Snippet)",
-          luasnip = "(Snippet)",
-          buffer = "(Buffer)",
-        })[entry.source.name]
-        vim_item.dup = ({
-          buffer = 1,
-          path = 1,
-          nvim_lsp = 0,
-        })[entry.source.name] or 0
+        vim_item.menu = lvim.builtin.cmp.formatting.source_names[entry.source.name]
+        vim_item.dup = lvim.builtin.cmp.formatting.duplicates[entry.source.name]
+          or lvim.builtin.cmp.formatting.duplicates_default
         return vim_item
       end,
     },


### PR DESCRIPTION
# Description
Settings related to popupmenu as duplicate entries source names are configurable now.
Why? Due to defaults duplicate setting many elements were missing from popupmenu (for example some snippets provided by luasnip) because they had equal names (as for snippet conflicting with for keyword).

**Before merging** I'd like to know if maintainers agree with setting all duplicate settings to 1 by default, so elements won't get hidden. If so I'll make another commit.

## How Has This Been Tested?
Put this in your `config.lua`
``` lua
lvim.builtin.cmp.formatting.source_names = {
	nvim_lsp = "(LSP)",
	emoji = "(Emoji)",
	path = "(Path)",
	calc = "(Calc)",
	cmp_tabnine = "(Tabnine)",
	vsnip = "(Snippet)",
	luasnip = "(Snippet)",
	buffer = "(Buffer)",
}

lvim.builtin.cmp.formatting.duplicates = {
	buffer = 1,
	path = 1,
	nvim_lsp = 0,
}

lvim.builtin.cmp.formatting.duplicates_default = 0
```
