### PR TITLE
feat: support nvim-cmp floating menu highlights

### DIFF
--- a/lua/onedarker/highlights.lua
+++ b/lua/onedarker/highlights.lua
@@ -94,6 +94,14 @@ local highlights = {
   TabLine = { fg = C.light_gray, bg = C.alt_bg },
   TabLineSel = { fg = C.fg, bg = C.alt_bg },
   TabLineFill = { fg = C.fg, bg = C.alt_bg },
+  CmpDocumentation = { fg = C.fg, bg = C.none },
+  CmpDocumentationBorder = { fg = C.fg_dark, bg = C.none },
+  CmpItemAbbr = { fg = C.fg, bg = C.none },
+  CmpItemAbbrDeprecated = { fg = C.gray, bg = C.none },
+  CmpItemAbbrMatch = { fg = C.cyan, bg = C.none },
+  CmpItemAbbrMatchFuzzy = { fg = C.cyan, bg = C.none },
+  CmpItemKind = { fg = C.blue, bg = C.none },
+  CmpItemMenu = { fg = C.light_gray, bg = C.none },
 }
 
 return highlights


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Support cmp new floating window in onedarker colorscheme
<img width="394" alt="Screen Shot 2021-10-09 at 1 14 56 AM" src="https://user-images.githubusercontent.com/10992695/136628072-3c4835c2-e7ed-4548-b20b-ad26af970efe.png">

# How to Test
you need to enable the `custom_menu` and also change the `Tab` and `S-Tab`

https://github.com/abzcoding/lvim/blob/main/lua/user/builtin.lua
