### PR TITLE
feat: configure multiple filetypes per provider

### DIFF
--- a/lua/lsp/null-ls/formatters.lua
+++ b/lua/lsp/null-ls/formatters.lua
@@ -23,7 +23,7 @@ function M.list_available(filetype)
   return formatters
 end
 
-function M.list_configured(formatter_configs, filetype)
+function M.list_configured(formatter_configs)
   local formatters, errors = {}, {}
 
   for _, fmt_config in ipairs(formatter_configs) do
@@ -42,7 +42,7 @@ function M.list_configured(formatter_configs, filetype)
         formatters[fmt_config.exe] = formatter.with {
           command = formatter_cmd,
           extra_args = fmt_config.args,
-          filetypes = { filetype },
+          filetypes = fmt_config.filetypes,
         }
       end
     end
@@ -51,12 +51,12 @@ function M.list_configured(formatter_configs, filetype)
   return { supported = formatters, unsupported = errors }
 end
 
-function M.setup(formatter_configs, filetype)
+function M.setup(formatter_configs)
   if vim.tbl_isempty(formatter_configs) then
     return
   end
 
-  local formatters_by_ft = M.list_configured(formatter_configs, filetype)
+  local formatters_by_ft = M.list_configured(formatter_configs)
   null_ls.register { sources = formatters_by_ft.supported }
 end
 

--- a/lua/lsp/null-ls/init.lua
+++ b/lua/lsp/null-ls/init.lua
@@ -15,10 +15,16 @@ function M:setup()
   require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
   for filetype, config in pairs(lvim.lang) do
     if not vim.tbl_isempty(config.formatters) then
-      formatters.setup(config.formatters, filetype)
+      vim.tbl_map(function(c)
+        c.filetypes = { filetype }
+      end, config.formatters)
+      formatters.setup(config.formatters)
     end
     if not vim.tbl_isempty(config.linters) then
-      linters.setup(config.linters, filetype)
+      vim.tbl_map(function(c)
+        c.filetypes = { filetype }
+      end, config.formatters)
+      linters.setup(config.linters)
     end
   end
 end

--- a/lua/lsp/null-ls/linters.lua
+++ b/lua/lsp/null-ls/linters.lua
@@ -23,7 +23,7 @@ function M.list_available(filetype)
   return linters
 end
 
-function M.list_configured(linter_configs, filetype)
+function M.list_configured(linter_configs)
   local linters, errors = {}, {}
 
   for _, lnt_config in pairs(linter_configs) do
@@ -42,7 +42,7 @@ function M.list_configured(linter_configs, filetype)
         linters[lnt_config.exe] = linter.with {
           command = linter_cmd,
           extra_args = lnt_config.args,
-          filetypes = { filetype },
+          filetypes = lnt_config.filetypes,
         }
       end
     end
@@ -51,13 +51,13 @@ function M.list_configured(linter_configs, filetype)
   return { supported = linters, unsupported = errors }
 end
 
-function M.setup(linter_configs, filetype)
+function M.setup(linter_configs)
   if vim.tbl_isempty(linter_configs) then
     return
   end
 
-  local linters_by_ft = M.list_configured(linter_configs, filetype)
-  null_ls.register { sources = linters_by_ft.supported }
+  local linters = M.list_configured(linter_configs)
+  null_ls.register { sources = linters.supported }
 end
 
 return M


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Allow setting the same provider for multiple filetypes.

Fixes #1724

## How Has This Been Tested?

Try this

```lua
local configs = {
  {exe = "prettier", filetypes = {"javascript", "typescript"} }
}
require("lsp.null-ls.formatters").setup(configs)
```
