### PR TITLE
fix(lsp): use correct check for formatter override

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -94,11 +94,10 @@ local function select_default_formater(client)
   Log:debug("Checking for formatter overriding for " .. client.name)
   local client_filetypes = client.config.filetypes or {}
   for _, filetype in ipairs(client_filetypes) do
-    if not vim.tbl_isempty(lvim.lang[filetype].formatters) then
+    if lvim.lang[filetype] and #vim.tbl_keys(lvim.lang[filetype].formatters) > 0 then
       Log:debug("Formatter overriding detected. Disabling formatting capabilities for " .. client.name)
       client.resolved_capabilities.document_formatting = false
       client.resolved_capabilities.document_range_formatting = false
-      return
     end
   end
 end

--- a/lua/lsp/utils.lua
+++ b/lua/lsp/utils.lua
@@ -10,12 +10,6 @@ function M.is_client_active(name)
   return false
 end
 
-function M.disable_formatting_capability(client)
-  -- FIXME: figure out a reasonable way to do this
-  client.resolved_capabilities.document_formatting = false
-  require("core.log"):debug(string.format("Turning off formatting capability for language server [%s] ", client.name))
-end
-
 function M.get_active_client_by_ft(filetype)
   local matches = {}
   local clients = vim.lsp.get_active_clients()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix broken check for formatters overriding.

Fixes #1705

## How Has This Been Tested?

```lua
lvim.lang.json.formatters = { { exe = "prettier" } }
```
