### PR TITLE
Disable lazy loading for auto-pairs

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -50,7 +50,6 @@ return {
   {
     "windwp/nvim-autopairs",
     -- event = "InsertEnter",
-    after = "nvim-cmp",
     config = function()
       require("core.autopairs").setup()
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Autopairs does not always get loaded correctly.  
I believe it's related to this packer issue wbthomason/packer.nvim#435

Fixes #1727

## How Has This Been Tested?
I've been running autopairs without lazy loading for the last few weeks.
