### PR TITLE
[Bugfix] nvim-tree `ls_disagnostics` has been replaced with `diagnostics`

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -12,7 +12,15 @@ function M.config()
       update_focused_file = {
         enable = true,
       },
-      lsp_diagnostics = true,
+      diagnostics = {
+        enable = true,
+        icons = {
+          hint = "",
+          info = "",
+          warning = "",
+          error = "",
+        },
+      },
       view = {
         width = 30,
         side = "left",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

https://github.com/kyazdani42/nvim-tree.lua/commit/94b8604e8689c295a78d7a868ba906cd061baa99

