### PR TITLE
[Bugfix] correct floating window position in Neovim 0.6 nightly

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -89,8 +89,10 @@ return {
   },
 
   -- Whichkey
+  -- TODO: change back to folke/which-key.nvim after folke got back
   {
-    "folke/which-key.nvim",
+    "abzcoding/which-key.nvim",
+    branch = "fix/neovim-6-position",
     config = function()
       require("lvim.core.which-key").setup()
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Till `folke` gets back, fix the `which-key` position on `neovim 0.6 nightly`
this is the current situation
<img width="1913" alt="Screen Shot 2021-10-10 at 1 49 07 PM" src="https://user-images.githubusercontent.com/10992695/136691788-dde0d04a-a5c3-444c-82d2-28c1752058a4.png">

this is what it looks like after the fix
<img width="1911" alt="Screen Shot 2021-10-10 at 1 48 32 PM" src="https://user-images.githubusercontent.com/10992695/136691794-43a1875c-5509-4dab-b56f-13f705e03f51.png">

credit goes to @zeertzjq