### PR TITLE
[Bugfix] anything not in nvim-tree setup should be set using 1/0

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -23,18 +23,18 @@ function M.config()
       },
     },
     show_icons = {
-      git = true,
-      folders = true,
-      files = true,
-      folder_arrows = true,
+      git = 1,
+      folders = 1,
+      files = 1,
+      folder_arrows = 1,
       tree_width = 30,
     },
     ignore = { ".git", "node_modules", ".cache" },
-    quit_on_open = false,
-    hide_dotfiles = true,
-    git_hl = true,
+    quit_on_open = 0,
+    hide_dotfiles = 1,
+    git_hl = 1,
     root_folder_modifier = ":t",
-    allow_resize = true,
+    allow_resize = 1,
     auto_ignore_ft = { "startify", "dashboard" },
     icons = {
       default = "",
@@ -73,7 +73,7 @@ function M.setup()
 
   -- Implicitly update nvim-tree when project module is active
   if lvim.builtin.project.active then
-    lvim.builtin.nvimtree.respect_buf_cwd = true
+    lvim.builtin.nvimtree.respect_buf_cwd = 1
     lvim.builtin.nvimtree.setup.update_cwd = true
     lvim.builtin.nvimtree.setup.disable_netrw = false
     lvim.builtin.nvimtree.setup.hijack_netrw = false


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

https://github.com/LunarVim/LunarVim/commit/c44550249b85307f668aff0d356c3461856c0e49 caused some problems
anything not included in the setup part should be set using 0/1
for example, this doesn't show icons
<img width="514" alt="Screen Shot 2021-10-10 at 2 20 00 PM" src="https://user-images.githubusercontent.com/10992695/136692494-2ac38c48-de79-45fc-bef8-9e025b8ca62e.png">

but this does
<img width="556" alt="Screen Shot 2021-10-10 at 2 19 36 PM" src="https://user-images.githubusercontent.com/10992695/136692483-63972e24-c4f3-478f-baba-18f0c9aaac9a.png">

because we are setting them using `vim.g` or `g["nvim_tree_" .. opt] = val`
