### PR TITLE
fix(config/log): show error in config instead of hiding

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -152,10 +152,10 @@ end
 -- @param config_path The path to the configuration overrides
 function M:load(config_path)
   config_path = config_path or self.get_user_config_path()
-  local ok, _ = pcall(dofile, config_path)
+  local ok, err = pcall(dofile, config_path)
   if not ok then
     if utils.is_file(user_config_file) then
-      Log:warn("Invalid configuration: " .. config_path)
+      Log:warn("Invalid configuration: " .. err)
     else
       Log:warn(string.format("Unable to find configuration file [%s]", config_path))
     end

--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -12,7 +12,7 @@ function Log:add_entry(msg, level)
   end
   local status_ok, plenary = pcall(require, "plenary")
   if status_ok then
-    local default_opts = { plugin = "lunarvim", level = lvim.log.level }
+    local default_opts = { plugin = "lunarvim", level = lvim.log.level, info_level = 4 }
     local handle = plenary.log.new(default_opts)
     handle[level:lower()](msg)
     self.__handle = handle


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Until #1737 is finished, this PR makes it so that LunarVim no longer hides the actual error causing a config failing to load and logs the actual error so a user can debug.

## How Has This Been Tested?

Add nonsense to the top of config.lua, like `asdffff` and save.
Open lvim and it will report the file, the line number, and the error.
