### PR TITLE
fix(null-ls): add common lsp-setup hooks

### DIFF
--- a/lua/lvim/lsp/null-ls/init.lua
+++ b/lua/lvim/lsp/null-ls/init.lua
@@ -12,6 +12,12 @@ function M:setup()
   end
 
   null_ls.config()
+  local default_opts = require("lvim.lsp").get_common_opts()
+
+  if vim.tbl_isempty(lvim.lsp.null_ls.setup or {}) then
+    lvim.lsp.null_ls.setup = default_opts
+  end
+
   require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
   for filetype, config in pairs(lvim.lang) do
     if not vim.tbl_isempty(config.formatters) then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add `get_common_opts` to null-ls setup, this includes: 
- `common_on_init` 
- `common_on_attach`
- `common_capabilities`

Fixes problems where LSP buffer mappings are expected to work with null-ls providers.

## How Has This Been Tested?

All buffer mappings should now work when only null-ls is running without a language server, assuming they're supported.
