### PR TITLE
fix(plenary): restore impatient caching for plenary

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -103,6 +103,7 @@ function M:init()
 
   -- FIXME: currently unreliable in unit-tests
   if not os.getenv "LVIM_TEST_ENV" then
+    _G.PLENARY_DEBUG = false
     require("lvim.impatient").setup {
       path = vim.fn.stdpath "cache" .. "/lvim_cache",
       enable_profiling = true,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Restores the ability for Plenary to be cached by impatient, in some cases significantly reducing startup time.

This was removed at some point, seemingly unintentionally, but was in there previously:
https://github.com/LunarVim/LunarVim/blob/68630329cd9ccd17dc89af09b5c229ddae53bdc8/init.lua#L15-L16

## How Has This Been Tested?

Open lvim, :LuaCacheProfile, note that plenary takes up a lot of time.
Exit lvim, open it again and :LuaCacheProfile, note that plenary takes up significantly less time.
