### PR TITLE
fix(cmp): fix <C-j> and <C-k> keybindings not working

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -204,6 +204,8 @@ M.config = function()
       { name = "crates" },
     },
     mapping = {
+      ["<C-k>"] = cmp.mapping.select_prev_item(),
+      ["<C-j>"] = cmp.mapping.select_next_item(),
       ["<C-d>"] = cmp.mapping.scroll_docs(-4),
       ["<C-f>"] = cmp.mapping.scroll_docs(4),
       -- TODO: potentially fix emmet nonsense

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -81,10 +81,6 @@ function M.config()
       ["<A-Down>"] = "<C-\\><C-N><C-w>j",
       ["<A-Left>"] = "<C-\\><C-N><C-w>h",
       ["<A-Right>"] = "<C-\\><C-N><C-w>l",
-      -- navigate tab completion with <c-j> and <c-k>
-      -- runs conditionally
-      ["<C-j>"] = { 'pumvisible() ? "\\<down>" : "\\<C-j>"', { expr = true, noremap = true } },
-      ["<C-k>"] = { 'pumvisible() ? "\\<up>" : "\\<C-k>"', { expr = true, noremap = true } },
     },
 
     ---@usage change or add keymappings for normal mode


### PR DESCRIPTION
# Description
When `nvim-cmp` experimental menu was introduced in LunarVim `<C-j>` and `<C-k>` stopped working.
This PR restores them.

## How Has This Been Tested?
Try opening a completion menu and press `<C-j>` to go to next element and `<C-k>` to go to previous element.
Of course you can use `<tab>`, `<s-tab>`, `<C-n>` and `<C-p>` too