### PR TITLE
chore: fix minimal_lsp.lua

### DIFF
--- a/.github/workflows/commitlint.config.js
+++ b/.github/workflows/commitlint.config.js
@@ -20,6 +20,7 @@ module.exports = {
       "always",
       [
         "build",
+        "chore",
         "ci",
         "docs",
         "feat",


### PR DESCRIPTION
# Description

- Fix the `minimal_lsp.lua` so it can be used for debugging.
- Add `nvim-lsp-installer` as an option to set the default command.

## How Has This Been Tested?

- `nvim -u minimal_lsp.lua`
