### PR TITLE
[BugFix] Adding transparency for EndOfBuffer

### DIFF
--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -69,6 +69,8 @@ M.load_commands = function()
     cmd "au ColorScheme * hi MsgArea ctermbg=none guibg=none"
     cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
     cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
+    cmd "au ColorScheme * hi EndOfBuffer ctermbg=none guibg=none"
+
     cmd "let &fcs='eob: '"
   end
 end


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

added the code for EndOf Buffer transparency. For colorschemes other than onedarker, EndofBuffer didn't turn to transparent.
So this will fix the said bug

