### PR TITLE
[Bugfix] Fix Windows environment variables in .ps1 scripts

### DIFF
--- a/utils/bin/lvim.ps1
+++ b/utils/bin/lvim.ps1
@@ -1,6 +1,6 @@
 $env:XDG_DATA_HOME = ($env:XDG_DATA_HOME, "$env:APPDATA", 1 -ne $null)[0]
-$env:XDG_CONFIG_HOME = ($env:XDG_CONFIG_HOME, "$LOCALAPPDATA", 1 -ne $null)[0]
-$env:XDG_CACHE_HOME = ($env:XDG_CACHE_HOME, "$TEMP", 1 -ne $null)[0]
+$env:XDG_CONFIG_HOME = ($env:XDG_CONFIG_HOME, "$env:LOCALAPPDATA", 1 -ne $null)[0]
+$env:XDG_CACHE_HOME = ($env:XDG_CACHE_HOME, "$env:TEMP", 1 -ne $null)[0]
 
 $env:LUNARVIM_RUNTIME_DIR = ($env:LUNARVIM_RUNTIME_DIR, "$env:XDG_DATA_HOME\lunarvim", 1 -ne $null)[0]
 $env:LUNARVIM_CONFIG_DIR = ($env:LUNARVIM_CONFIG_DIR, "$env:XDG_CONFIG_HOME\lvim", 1 -ne $null)[0]

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -6,8 +6,8 @@ $LV_REMOTE = ($LV_REMOTE, "lunarvim/lunarvim.git", 1 -ne $null)[0]
 $INSTALL_PREFIX = ($INSTALL_PREFIX, "$HOME\.local", 1 -ne $null)[0]
 
 $env:XDG_DATA_HOME = ($env:XDG_DATA_HOME, "$env:APPDATA", 1 -ne $null)[0]
-$env:XDG_CONFIG_HOME = ($env:XDG_CONFIG_HOME, "$LOCALAPPDATA", 1 -ne $null)[0]
-$env:XDG_CACHE_HOME = ($env:XDG_CACHE_HOME, "$TEMP", 1 -ne $null)[0]
+$env:XDG_CONFIG_HOME = ($env:XDG_CONFIG_HOME, "$env:LOCALAPPDATA", 1 -ne $null)[0]
+$env:XDG_CACHE_HOME = ($env:XDG_CACHE_HOME, "$env:TEMP", 1 -ne $null)[0]
 $env:LUNARVIM_RUNTIME_DIR = ($env:LUNARVIM_RUNTIME_DIR, "$env:XDG_DATA_HOME\lunarvim", 1 -ne $null)[0]
 $env:LUNARVIM_CONFIG_DIR = ($env:LUNARVIM_CONFIG_DIR, "$env:XDG_CONFIG_HOME\lvim", 1 -ne $null)[0]
 $env:LUNARVIM_CACHE_DIR = ($env:LUNARVIM_CACHE_DIR, "$env:XDG_CACHE_HOME\lvim", 1 -ne $null)[0]
@@ -276,4 +276,3 @@ function create_alias {
 }
 
 main "$args"
-


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

As noted in #1671, `$env:LUNARVIM_CONFIG_DIR` defaults to `C:\lvim\`. This is because `$LOCALAPPDATA` and `$TEMP` are not default variables in PowerShell.

This PR updates those variables to reference `$env:`. See below:
- `$LOCALAPPDATA` -> `$env:LOCALAPPDATA`
- `$TEMP` -> `$env:TEMP`

Fixes #1671

## How Has This Been Tested?

- Run `lvim` with a populated `C:\lvim\` (old location) but with nothing in `%LOCALAPPDATA%\lvim\` 
- `:messages` will show errors about missing plugins when initially launching LunarVim.
- Copy the contents of `C:\lvim\` to `%LOCALAPPDATA%\lvim\`
- Run `lvim` again and everything starts as normal
