### PR TITLE
[Bugfix] lualine: use tabstop in spaces component when sensible

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -122,11 +122,14 @@ return {
   progress = { "progress", cond = conditions.hide_in_width, color = {} },
   spaces = {
     function()
-      local label = "Spaces: "
       if not vim.api.nvim_buf_get_option(0, "expandtab") then
-        label = "Tab size: "
+        return "Tab size: " .. vim.api.nvim_buf_get_option(0, "tabstop") .. " "
       end
-      return label .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
+      local size = vim.api.nvim_buf_get_option(0, "shiftwidth")
+      if size == 0 then
+        size = vim.api.nvim_buf_get_option(0, "tabstop")
+      end
+      return "Spaces: " .. size .. " "
     end,
     cond = conditions.hide_in_width,
     color = {},


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The `spaces` component for lualine blindly uses the `shiftwidth` option
regardless of the setting of `expandtab`.

There is no guarantee that shiftwidth is always set to the same value as
tabstop.  Additionally, when shiftwidth is set to the value zero (0) the
value of tabstop is used instead.  As such, it is not useful to solely
rely on that one option.  When 'noexpandtab' is set, the shiftwidth
value becomes somewhat meaningless.

From :help 'shiftwidth':
When zero the 'ts' value will be used.

## How Has This Been Tested?

Testing done on Ubuntu 20.04.3 LTS inside WSL2.
My config contains the following snippet:
```
local components = require("lvim.core.lualine.components")
lvim.builtin.lualine.sections.lualine_y = {
        components.spaces,
}
```
Just playing around with `expandtab`, `shiftwidth` and `tabstop` gets the following results:
```set expandtab tabstop=7 shiftwidth=5```
![image](https://user-images.githubusercontent.com/72616153/137990255-00085a89-fd09-4230-9210-6c1fef97529e.png)

```set expandtab tabstop=7 shiftwidth=0```
As per vim help, `tabstop` is used when `shiftwidth=0`.
![image](https://user-images.githubusercontent.com/72616153/137990498-f04ae4c4-83f7-4296-9024-2f112af6bbf4.png)

```set noexpandtab tabstop=7 shiftwidth=5```
![image](https://user-images.githubusercontent.com/72616153/137990533-fdb7ed61-dc8b-40c0-9d90-59786948896a.png)

```set noexpandtab tabstop=7 shiftwidth=0```
Same as above, `shiftwidth` is irrelevant when `noexpandtab` is set.
![image](https://user-images.githubusercontent.com/72616153/137990533-fdb7ed61-dc8b-40c0-9d90-59786948896a.png)

