### PR TITLE
refactor(info): new layout with less clutter

### DIFF
--- a/lua/lvim/core/info.lua
+++ b/lua/lvim/core/info.lua
@@ -23,7 +23,6 @@ local function make_formatters_info(ft)
   local supported_formatters = null_formatters.list_available(ft)
   local section = {
     "Formatters info",
-    "",
     fmt(
       "* Active: %s%s",
       table.concat(registered_formatters, "  , "),
@@ -40,9 +39,7 @@ local function make_linters_info(ft)
   local supported_linters = null_linters.list_available(ft)
   local registered_linters = null_linters.list_supported_names(ft)
   local section = {
-    "",
     "Linters info",
-    "",
     fmt(
       "* Active: %s%s",
       table.concat(registered_linters, "  , "),
@@ -104,7 +101,7 @@ function M.toggle_popup(ft)
   local ts_info = {
     "Treesitter info",
     fmt("* current buffer:            %s", is_treesitter_active()),
-    fmt("* other buffers:             [%s]", table.concat(ts_active_buffers, ", ")),
+    fmt("* list:                      [%s]", table.concat(ts_active_buffers, ", ")),
   }
 
   local lsp_info = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

New `LvimInfo` layout: 
- add current buffer number.
- add treesitter status for all buffers.
- less redundant info about setting up formatters and linters.

Fixes #1362, #1759

