### PR TITLE
fix(onedarker): fix color of concealed characters

### DIFF
--- a/lua/onedarker/highlights.lua
+++ b/lua/onedarker/highlights.lua
@@ -42,7 +42,7 @@ local highlights = {
   CursorIM = { fg = C.cursor_fg, bg = C.cursor_bg },
   TermCursor = { fg = C.cursor_fg, bg = C.cursor_bg },
   TermCursorNC = { fg = C.cursor_fg, bg = C.cursor_bg },
-  Conceal = { fg = C.accent },
+  Conceal = { fg = C.accent, bg = Config.transparent_background and "NONE" or C.bg },
   Directory = { fg = C.blue },
   SpecialKey = { fg = C.blue, style = "bold" },
   Title = { fg = C.blue, style = "bold" },


### PR DESCRIPTION
Currently, the background for concealed characters is light gray, making it unreadable.
This is a attempt to fix that by 

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Currently, the background for concealed characters is light gray, making it unreadable.
This is a attempt to fix that by specifying the 'bg' property in 'highlights.lua'.

## How Has This Been Tested?

1. Select the onedarker colorscheme `:colorscheme onedarker`
2. Install the vimtex plugin `lvim.plugins = {{"lervag/vimtex"}}`
3. Open some .tex file and add some maths `$\alpha \beta$`
4. Set `conceallevel=2` (and add a new line).

