### PR TITLE
[Bugfix] ensure the log level is never nil

### DIFF
--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -90,6 +90,9 @@ function Log:init()
     vim.notify = function(msg, vim_log_level, opts)
       nvim_notify_params = opts or {}
       -- vim_log_level can be omitted
+      if vim_log_level == nil then
+        vim_log_level = Log.levels["INFO"]
+      end
       if type(vim_log_level) == "string" then
         vim_log_level = Log.levels[(vim_log_level):upper() or "INFO"]
       end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I am using https://github.com/ruifm/gitlinker.nvim and when I try to open a link, somehow the `vim_log_level` is nil. This change ensure the log level cannot be nil and sets the default to INFO.

## How Has This Been Tested?

With this change the link are opened properly.