### PR TITLE
fix(plugin): Update lualine repo name

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -132,7 +132,7 @@ return {
   -- Status Line and Bufferline
   {
     -- "hoob3rt/lualine.nvim",
-    "shadmansaleh/lualine.nvim",
+    "nvim-lualine/lualine.nvim",
     -- "Lunarvim/lualine.nvim",
     config = function()
       require("lvim.core.lualine").setup()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`shadmansaleh/lualine.nvim` moved to `nvim-lualine/lualine.nvim`

## How Has This Been Tested?
A warning popped up saying that the `lualine` plugin repo "moved", so i changed the repo, did Packer-Sync and now it does not appear anymore.