### PR TITLE
fix(log): don't rely on lvim.builtin.notify.active

### DIFF
--- a/lua/lvim/config/defaults.lua
+++ b/lua/lvim/config/defaults.lua
@@ -28,7 +28,7 @@ return {
         float_opts = {},
       },
     },
-    ---@usage set to false to restore the default behavior of vim.notify
-    override_notify = true,
+    -- currently disabled due to instabilities
+    override_notify = false,
   },
 }

--- a/lua/lvim/core/notify.lua
+++ b/lua/lvim/core/notify.lua
@@ -2,30 +2,44 @@ local M = {}
 
 function M.config()
   local pallete = require "onedarker.palette"
+
   lvim.builtin.notify = {
     active = false,
     on_config_done = nil,
     -- TODO: update after https://github.com/rcarriga/nvim-notify/pull/24
     opts = {
-      ---@usage Animation style (see below for details)
-      stages = "fade_in_slide_out",
+      ---@usage Animation style one of { "fade", "slide", "fade_in_slide_out", "static" }
+      stages = "slide",
 
-      ---@usage Default timeout for notifications
+      ---@usage timeout for notifications in ms, default 5000
       timeout = 5000,
 
-      ---@usage For stages that change opacity this is treated as the highlight behind the window
+      ---@usage highlight behind the window for stages that change opacity
       background_colour = pallete.fg,
 
       ---@usage Icons for the different levels
       icons = {
-        ERROR = "",
-        WARN = "",
-        INFO = "",
+        ERROR = "",
+        WARN = "",
+        INFO = "",
         DEBUG = "",
         TRACE = "✎",
       },
     },
   }
+end
+
+M.params_injecter = function(_, entry)
+  -- FIXME: this is currently getting ignored or is not passed correctly
+  for key, value in pairs(lvim.builtin.notify.opts) do
+    entry[key] = value
+  end
+  return entry
+end
+
+M.default_namer = function(logger, entry)
+  entry["title"] = logger.name
+  return entry
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

We can't rely on `lvim.builtin.notify.active` since the logger can be used before the config loader has been initialized.

Fixes #1830

## How Has This Been Tested?

Not sure how to test this, since it seems to only fail on macOS.
