### PR TITLE
feat: make cmp keyword_length easier to configure

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -126,6 +126,12 @@ M.config = function()
       behavior = cmp.ConfirmBehavior.Replace,
       select = false,
     },
+    completion = {
+      ---@usage vim's `completeopt` setting. Warning: Be careful when changing this value.
+      completeopt = "menu,menuone,noinsert",
+      ---@usage The minimum length of a word to complete on.
+      keyword_length = 1,
+    },
     experimental = {
       ghost_text = true,
       native_menu = false,
@@ -241,7 +247,7 @@ M.config = function()
       }),
 
       ["<C-Space>"] = cmp.mapping.complete(),
-      ["<C-e>"] = cmp.mapping.close(),
+      ["<C-e>"] = cmp.mapping.abort(),
       ["<CR>"] = cmp.mapping(function(fallback)
         if cmp.visible() and cmp.confirm(lvim.builtin.cmp.confirm_opts) then
           return


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- global settings applied to all sources
```lua
lvim.builtin.cmp.completion.keyword_length = 2 --default 1
```
- per source configuration
```lua
lvim.builtin.cmp.sources[1].keyword_length = 5 --default 1
```
- also added max_count by default
```lua
lvim.builtin.cmp.sources[1].max_count = 20 --default 200
```
