### PR TITLE
fix(lsp): disable eslint server by default

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -46,6 +46,8 @@ return {
     "ansiblels",
     "denols",
     "ember",
+    "eslint",
+    "eslintls",
     "jedi_language_server",
     "pylsp",
     "rome",


### PR DESCRIPTION
# Description

Add `eslint` language server to `lvim.lsp.override` by default.
