### PR TITLE
feat(cmp): expose lunarvim's cmp helper methods

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -137,10 +137,10 @@ local function jumpable(dir)
     return false
   end
 
-  if dir ~= -1 then
-    return inside_snippet() and seek_luasnip_cursor_node() and luasnip.jumpable()
-  else
+  if dir == -1 then
     return inside_snippet() and luasnip.jumpable(-1)
+  else
+    return inside_snippet() and seek_luasnip_cursor_node() and luasnip.jumpable()
   end
 end
 M.methods.jumpable = jumpable


### PR DESCRIPTION
# Description

See:
https://github.com/LunarVim/LunarVim/pull/1806#issue-761742689

## How Has This Been Tested?

You can redefine some mappings with a similar code (this code from @xeluxee's `config.lua` redefines `<Tab>` behavior so that if complete menu is open and a snippet is available snippet expansions will have precedence):
``` lua
local lb = lvim.builtin
local cmp = require("cmp")
local luasnip = require("luasnip")
local lccm = require("lvim.core.cmp").methods

lb.cmp.mapping["<Tab>"] = cmp.mapping(function(fallback)
  if luasnip.expandable() then
    luasnip.expand()
  elseif lccm.jumpable() then
    luasnip.jump(1)
  elseif cmp.visible() then
    cmp.select_next_item()
  elseif lccm.check_backspace() then
    fallback()
  elseif lccm.is_emmet_active() then
    return vim.fn["cmp#complete"]()
  else
    fallback()
  end
end, { "i", "s", }
)
lb.cmp.mapping["<S-Tab>"] = cmp.mapping(function(fallback)
  if lccm.jumpable(-1) then
    luasnip.jump(-1)
  elseif cmp.visible() then
    cmp.select_prev_item()
  else
    fallback()
  end
end, { "i", "s", }
)
```