### PR TITLE
fix(lsp): install templates and configure overrides for custom providers

### DIFF
--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -26,8 +26,8 @@ local function resolve_config(name, user_config)
     capabilities = require("lvim.lsp").common_capabilities(),
   }
 
-  local status_ok, custom_config = pcall(require, "lvim.lsp/providers/" .. name)
-  if status_ok then
+  local has_custom_provider, custom_config = pcall(require, "lvim/lsp/providers/" .. name)
+  if has_custom_provider then
     Log:debug("Using custom configuration for requested server: " .. name)
     config = vim.tbl_deep_extend("force", config, custom_config)
   end
@@ -70,7 +70,11 @@ function M.setup(server_name, user_config)
   if server_available and ensure_installed(requested_server) then
     requested_server:setup(config)
   else
-    require("lspconfig")[server_name].setup(config)
+    -- since it may not be installed, don't attempt to configure the LSP unless there is a custom provider
+    local has_custom_provider, _ = pcall(require, "lvim/lsp/providers/" .. server_name)
+    if has_custom_provider then
+      require("lspconfig")[server_name].setup(config)
+    end
   end
 end
 

--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -19,7 +19,8 @@ end
 ---@param server_name string name of a valid language server, e.g. pyright, gopls, tsserver, etc.
 ---@param dir string the full path to the desired directory
 function M.generate_ftplugin(server_name, dir)
-  if vim.tbl_contains(lvim.lsp.override, server_name) then
+  local has_custom_provider, _ = pcall(require, "lvim/lsp/providers/" .. server_name)
+  if vim.tbl_contains(lvim.lsp.override, server_name) and not has_custom_provider then
     return
   end
 


### PR DESCRIPTION
# Description

As it is, there is no built-in mechanism to install a ftplugin even if there is a custom provider and an override passed.

On a related note, when a server is not installed and there is no provider override, LunarVim will still try to run lspconfig for a server. This can lead to a large group of error messages when a server is not installed and not intended to be configured.

Currently, in the case where an override is passed to essentially blacklist something (like `rome`), LunarVim will still try to run lspconfig. For example, when opening an `.html` file, it will still attempt to find the command `rome` if the server is not installed and overridden, similarly with `emmet_ls`.

This attempts to fix all of the above.

## How Has This Been Tested?

Having these files:

lvim/config.lua
``` lua
lvim.lsp.automatic_servers_installation = false
vim.list_extend(lvim.lsp.override, {
   "emmet_ls", "tsserver"
})
lvim.plugins = {
  {
    "jose-elias-alvarez/nvim-lsp-ts-utils",
    ft = {"typescript", "typescriptreact"}
  },
}
```

lvim/lua/lvim/lsp/providers/tsserver.lua
``` lua
local status_ok, ts_utils = pcall(require, "nvim-lsp-ts-utils")
if not status_ok then
  vim.cmd [[ packadd nvim-lsp-ts-utils ]]
  ts_utils = require "nvim-lsp-ts-utils"
end

-- defaults
ts_utils.setup {
  debug = false,
  disable_commands = false,
  enable_import_on_completion = false,
  import_all_timeout = 5000, -- ms

  -- eslint
  eslint_enable_code_actions = true,
  eslint_enable_disable_comments = true,
  eslint_bin = "eslint_d",
  eslint_config_fallback = nil,
  eslint_enable_diagnostics = true,

  -- formatting
  enable_formatting = false,
  formatter = "prettierd",
  formatter_config_fallback = nil,

  -- parentheses completion
  complete_parens = false,
  signature_help_in_parens = false,

  -- update imports on file move
  update_imports_on_move = false,
  require_confirmation_on_move = false,
  watch_dir = nil,
}
local opts = {
  on_attach = function(client, bufnr)
    ts_utils.setup_client(client)
    require("lvim.lsp").common_on_attach(client, bufnr)
  end,
}

return opts
```

Run: `:LvimCacheReset`
Then open an `.html` file, there shouldn't be any complaints about `rome` or `emmet_ls` if they aren't installed
Open a `.ts` file, the proper server should load