### PR TITLE
fix(whick-key): add missing space (only windows cause problem)

### DIFF
--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -177,7 +177,7 @@ M.config = function()
       L = {
         name = "+LunarVim",
         c = {
-          "<cmd>edit" .. get_config_dir() .. "/config.lua<cr>",
+          "<cmd>edit " .. get_config_dir() .. "/config.lua<cr>",
           "Edit config.lua",
         },
         f = {


### PR DESCRIPTION
# Description

Fix problem when using `<Leader>Lc` to edit `config.lua` in windows platform



