### PR TITLE
refactor: more configurable format-on-save

### DIFF
--- a/lua/lvim/config/defaults.lua
+++ b/lua/lvim/config/defaults.lua
@@ -3,7 +3,12 @@ return {
   colorscheme = "onedarker",
   line_wrap_cursor_movement = true,
   transparent_window = false,
-  format_on_save = true,
+  format_on_save = {
+    ---@usage pattern string pattern used for the autocommand (Default: '*')
+    pattern = "*",
+    ---@usage timeout number timeout in ms for the format request (Default: 1000)
+    timeout = 1000,
+  },
   keys = {},
 
   builtin = {},

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -20,7 +20,7 @@ end
 -- Define lvim global variable
 function M:init()
   if vim.tbl_isempty(lvim or {}) then
-    lvim = require "lvim.config.defaults"
+    lvim = vim.deepcopy(require "lvim.config.defaults")
     local home_dir = vim.loop.os_homedir()
     lvim.vsnip_dir = utils.join_paths(home_dir, ".config", "snippets")
     lvim.database = { save_location = utils.join_paths(home_dir, ".config", "lunarvim_db"), auto_execute = 1 }

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -114,7 +114,8 @@ function M:reload()
   M:load()
 
   local plugins = require "lvim.plugins"
-  utils.toggle_autoformat()
+  local autocmds = require "lvim.core.autocmds"
+  autocmds.configure_format_on_save()
   local plugin_loader = require "lvim.plugin-loader"
   plugin_loader.cache_clear()
   plugin_loader.load { plugins, lvim.plugins }

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -59,20 +59,30 @@ function M.load_augroups()
   }
 end
 
+local get_format_on_save_opts = function()
+  local defaults = require("lvim.config.defaults").format_on_save
+  -- accept a basic boolean `lvim.format_on_save=true`
+  if type(lvim.format_on_save) ~= "table" then
+    return defaults
+  end
+
+  return {
+    pattern = lvim.format_on_save.pattern or defaults.pattern,
+    timeout = lvim.format_on_save.timeout or defaults.timeout,
+  }
+end
+
 function M.enable_format_on_save(opts)
-  opts = opts or {}
-  opts.pattern = opts.pattern or "*"
-  opts.timeout_ms = opts.timeout_ms or 1000
   local fmd_cmd = string.format(":silent lua vim.lsp.buf.formatting_sync({}, %s)", opts.timeout_ms)
   M.define_augroups {
     format_on_save = { { "BufWritePre", opts.pattern, fmd_cmd } },
   }
-  Log:debug "format-on-save set to true"
+  Log:debug "enabled format-on-save"
 end
 
 function M.disable_format_on_save()
   M.remove_augroup "format_on_save"
-  Log:debug "format-on-save set to false"
+  Log:debug "disabled format-on-save"
 end
 
 function M.configure_format_on_save()
@@ -81,7 +91,7 @@ function M.configure_format_on_save()
       M.remove_augroup "format_on_save"
       Log:debug "reloading format-on-save configuration"
     end
-    local opts = { pattern = lvim.format_on_save_pattern, timeout_ms = lvim.format_on_save_timeout }
+    local opts = get_format_on_save_opts()
     M.enable_format_on_save(opts)
   else
     M.disable_format_on_save()
@@ -90,7 +100,7 @@ end
 
 function M.toggle_format_on_save()
   if vim.fn.exists "#format_on_save" == 0 then
-    local opts = { pattern = lvim.format_on_save_pattern, timeout_ms = lvim.format_on_save_timeout }
+    local opts = get_format_on_save_opts()
     M.enable_format_on_save(opts)
   else
     M.disable_format_on_save()

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -87,7 +87,7 @@ end
 
 function M.configure_format_on_save()
   if lvim.format_on_save then
-    if vim.fn.exists "#format_on_save" == 1 then
+    if vim.fn.exists "#format_on_save#BufWritePre" == 1 then
       M.remove_augroup "format_on_save"
       Log:debug "reloading format-on-save configuration"
     end
@@ -99,7 +99,7 @@ function M.configure_format_on_save()
 end
 
 function M.toggle_format_on_save()
-  if vim.fn.exists "#format_on_save" == 0 then
+  if vim.fn.exists "#format_on_save#BufWritePre" == 0 then
     local opts = get_format_on_save_opts()
     M.enable_format_on_save(opts)
   else

--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -16,6 +16,7 @@ M.defaults = {
   [[ command! LvimUpdate lua require('lvim.bootstrap').update() ]],
   [[ command! LvimSyncCorePlugins lua require('lvim.plugin-loader'):sync_core_plugins() ]],
   [[ command! LvimReload lua require('lvim.config'):reload() ]],
+  [[ command! LvimToggleFormatOnSave lua require('lvim.core.autocmds').toggle_format_on_save() ]],
 }
 
 M.load = function(commands)

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -171,7 +171,7 @@ function M.setup()
 
   require("lvim.lsp.null-ls").setup()
 
-  require("lvim.utils").toggle_autoformat()
+  require("lvim.core.autocmds").configure_format_on_save()
 end
 
 return M

--- a/lua/lvim/utils/init.lua
+++ b/lua/lvim/utils/init.lua
@@ -1,5 +1,4 @@
 local utils = {}
-local Log = require "lvim.core.log"
 local uv = vim.loop
 
 -- recursive Print (structure, limit, separator)
@@ -56,31 +55,6 @@ function utils.generate_settings()
 
   -- closes the open file
   io.close(file)
-end
-
--- autoformat
-function utils.toggle_autoformat()
-  if lvim.format_on_save then
-    require("lvim.core.autocmds").define_augroups {
-      autoformat = {
-        {
-          "BufWritePre",
-          "*",
-          ":silent lua vim.lsp.buf.formatting_sync()",
-        },
-      },
-    }
-    Log:debug "Format on save active"
-  end
-
-  if not lvim.format_on_save then
-    vim.cmd [[
-      if exists('#autoformat#BufWritePre')
-        :autocmd! autoformat
-      endif
-    ]]
-    Log:debug "Format on save off"
-  end
 end
 
 function utils.unrequire(m)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- add `lvim.format_on_save.pattern`
- add `lvim.format_on_save.timeout_ms`
- add `LvimToggleFormatOnSave`

Fixes #1561, #1684

## How Has This Been Tested?

```lua
lvim.format_on_save = {
	pattern = "*.lua"
}
```

You can also try `:LvimToggleFormatOnSave` to allow saving files without formatting.
