### PR TITLE
fix(terminal): whichkey -> which-key

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -88,7 +88,7 @@ M.add_exec = function(opts)
     term_mode = { [opts.keymap] = exec_func },
   }
 
-  local wk_status_ok, wk = pcall(require, "whichkey")
+  local wk_status_ok, wk = pcall(require, "which-key")
   if not wk_status_ok then
     return
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

There's a typo in `terminal.lua` which results in the keymap label not being registered.

