### PR TITLE
fix(luasnip-cmp): <CR> don't remove default val

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -302,9 +302,9 @@ M.config = function()
           fallback()
         end
       end, {
-			"i",
-			"s",
-		}),
+	"i",
+	"s",
+      }),
     },
   }
 end


### PR DESCRIPTION
# Description
Tab mapping on luasnip skips current value in snippet if nothing is typed.
However, additional <CR> mapping for jumping in snippets remove the default value of snippet.

## How Has This Been Tested?

- Enable <CR> mapping to jump snippets.
- <CR> behavior is not the same as <Tab> behaviour, it removes initial value of snippet. (e.g _int_  i=0; if <CR> pressed on enter to jump to 'i', it deletes 'int'.


