### PR TITLE
feat(null-ls): include hover capabilities

### DIFF
--- a/lua/lvim/lsp/null-ls/hovers.lua
+++ b/lua/lvim/lsp/null-ls/hovers.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+local Log = require "lvim.core.log"
+
+local null_ls = require "null-ls"
+local services = require "lvim.lsp.null-ls.services"
+local method = null_ls.methods.HOVER
+
+function M.setup(formatter_configs)
+  if vim.tbl_isempty(formatter_configs) then
+    return
+  end
+
+  local registered = services.register_sources(formatter_configs, method)
+
+  if #registered > 0 then
+    Log:debug("Registered the following hovers: " .. unpack(registered))
+  end
+end
+
+return M


### PR DESCRIPTION
# Description

This change adds hover capabilitites to LunarVim based on recent added [hover in null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#hover).

It follows already added null-ls capabilities in order to give a well known interface to current users.

<!--- Please list any dependencies that are required for this change. --->
This change has no external dependencies.

The documentation was added on [PR312](https://github.com/LunarVim/lunarvim.org/pull/312) of the LunarVim's docs.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
I include it on my own configuration since a while. I decide to include in the LunarVim's one to contribute.

