### PR TITLE
refactor(treesitter)!: use auto-install by default

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -95,69 +95,6 @@ function M.config()
   }
 end
 
----@class bundledParsersOpts
----@field name_only boolean
----@field filter function
-
----Retrives a list of bundled parsers paths (any parser not found in default `install_dir`)
----@param opts bundledParsersOpts
----@return string[]
-local function get_parsers(opts)
-  opts = opts or {}
-  opts.filter = opts.filter or function()
-    return true
-  end
-
-  local bundled_parsers = vim.tbl_filter(opts.filter, vim.api.nvim_get_runtime_file("parser/*.so", true))
-
-  if opts.name_only then
-    bundled_parsers = vim.tbl_map(function(parser)
-      return vim.fn.fnamemodify(parser, ":t:r")
-    end, bundled_parsers)
-  end
-
-  return bundled_parsers
-end
-
----Checks if parser is installed with nvim-treesitter
----@param lang string
----@return boolean
-local function is_installed(lang)
-  local configs = require "nvim-treesitter.configs"
-  local result = get_parsers {
-    filter = function(parser)
-      local install_dir = configs.get_parser_install_dir()
-      return vim.startswith(parser, install_dir) and (vim.fn.fnamemodify(parser, ":t:r") == lang)
-    end,
-  }
-  local parser_file = result and result[1] or ""
-  local stat = vim.loop.fs_stat(parser_file)
-  return stat and stat.type == "file"
-end
-
-local function ensure_updated_bundled()
-  local configs = require "nvim-treesitter.configs"
-  local bundled_parsers = get_parsers {
-    name_only = true,
-    filter = function(parser)
-      local install_dir = configs.get_parser_install_dir()
-      return not vim.startswith(parser, install_dir)
-    end,
-  }
-
-  vim.api.nvim_create_autocmd("VimEnter", {
-    callback = function()
-      local missing = vim.tbl_filter(function(parser)
-        return not is_installed(parser)
-      end, bundled_parsers)
-
-      if #missing > 0 then
-        vim.cmd { cmd = "TSInstall", args = missing, bang = true }
-      end
-    end,
-  })
-end
-
 function M.setup()
   -- avoid running in headless mode since it's harder to detect failures
   if #vim.api.nvim_list_uis() == 0 then
@@ -175,14 +112,9 @@ function M.setup()
 
   treesitter_configs.setup(opts)
 
-  ensure_updated_bundled()
-
   if lvim.builtin.treesitter.on_config_done then
     lvim.builtin.treesitter.on_config_done(treesitter_configs)
   end
 end
-
-M.get_parsers = get_parsers
-M.is_installed = is_installed
 
 return M


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- refactor(treesitter)!: use auto-install by default
- fix(tree-sitter): remove old workaround

## How Has This Been Tested?

- run `TSUninstall lua` (you should see a warning message, that's expected)
- close lvim
- open lvim again
    - if you have `lua` in `ensure_installed` then you should see treesitter automatically installing lua (and any outdated bundled parsers, e,g. help)
    - open a a `lua` file and see the parser get installed automatically
