### PR TITLE
fix(lazygit): fix too larg size(100000) for lazygit_toogle method

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -148,14 +148,18 @@ end
 
 M.lazygit_toggle = function()
   local Terminal = require("toggleterm.terminal").Terminal
+
+  local columns = vim.o.columns
+  local lines = vim.o.lines
+
   local lazygit = Terminal:new {
     cmd = "lazygit",
     hidden = true,
     direction = "float",
     float_opts = {
       border = "none",
-      width = 100000,
-      height = 100000,
+      width = columns or 300,
+      height = lines or 200,
     },
     on_open = function(_)
       vim.cmd "startinsert!"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

In macOS, when I used an nvim-gui like [Neovide](https://neovide.dev), when I set up the [multigrid](https://neovide.dev/command-line-reference.html#multigrid) feature, eovide will create the stage realistically -- will cause a memory leak by consuming a lot of memory, which will cause the Neovide to get hanging.

![image](https://github.com/LunarVim/LunarVim/assets/804292/00000e7a-769c-4484-a777-189787befca9)


<!--- Please list any dependencies that are required for this change. --->

Just detect `columns` `lines` to set plugin toggleterm's  `width` and `height`, no dependencies.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:lua require 'lvim.core.terminal'.lazygit_toggle()`


