### PR TITLE
chore(diagnostic): sign text config

### DIFF
--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -77,12 +77,11 @@ M.load_default_options = function()
 
   local default_diagnostic_config = {
     signs = {
-      active = true,
-      values = {
-        { name = "DiagnosticSignError", text = lvim.icons.diagnostics.Error },
-        { name = "DiagnosticSignWarn", text = lvim.icons.diagnostics.Warning },
-        { name = "DiagnosticSignHint", text = lvim.icons.diagnostics.Hint },
-        { name = "DiagnosticSignInfo", text = lvim.icons.diagnostics.Information },
+      text = {
+        [vim.diagnostic.severity.ERROR] = lvim.icons.diagnostics.Error,
+        [vim.diagnostic.severity.WARN] = lvim.icons.diagnostics.Warning,
+        [vim.diagnostic.severity.HINT] = lvim.icons.diagnostics.Hint,
+        [vim.diagnostic.severity.INFO] = lvim.icons.diagnostics.Information,
       },
     },
     virtual_text = true,

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -94,10 +94,10 @@ function M.setup()
     return
   end
 
-  if lvim.use_icons then
-    for _, sign in ipairs(vim.tbl_get(vim.diagnostic.config(), "signs", "values") or {}) do
-      vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = sign.name })
-    end
+  if not lvim.use_icons then
+    vim.diagnostic.config {
+      signs = {},
+    }
   end
 
   if not utils.is_directory(lvim.lsp.templates_dir) then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adjusted the way sign text is set up.
Sign icons is no longer configured with `vim.fn.sign_define()`

