### PR TITLE
feat(windows): support cmd prompt

### DIFF
--- a/utils/bin/lvim.bat
+++ b/utils/bin/lvim.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal enabledelayedexpansion
+
+if not defined XDG_DATA_HOME set XDG_DATA_HOME=%APPDATA%
+if not defined XDG_CONFIG_HOME set XDG_CONFIG_HOME=%LOCALAPPDATA%
+if not defined XDG_CACHE_HOME set XDG_CACHE_HOME=%TEMP%
+
+if not defined LUNARVIM_RUNTIME_DIR set LUNARVIM_RUNTIME_DIR=!XDG_DATA_HOME!\lunarvim
+if not defined LUNARVIM_CONFIG_DIR set LUNARVIM_CONFIG_DIR=!XDG_CONFIG_HOME!\lvim
+if not defined LUNARVIM_CACHE_DIR set LUNARVIM_CACHE_DIR=!XDG_CACHE_HOME!\lvim
+if not defined LUNARVIM_BASE_DIR set LUNARVIM_BASE_DIR=!LUNARVIM_RUNTIME_DIR!\lvim
+
+nvim -u "!LUNARVIM_BASE_DIR!\init.lua" %*

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -182,6 +182,7 @@ function setup_shim() {
     }
 
     Copy-Item -Force "$env:LUNARVIM_BASE_DIR\utils\bin\lvim.ps1" "$INSTALL_PREFIX\bin\lvim.ps1"
+    Copy-Item -Force "$env:LUNARVIM_BASE_DIR\utils\bin\lvim.bat" "$INSTALL_PREFIX\bin\lvim.bat"
 }
 
 function uninstall_lvim() {


### PR DESCRIPTION
# Description

Support lvim running in Windows Command Prompt (cmd.exe), simply translate `lvim.ps1` into `lvim.bat` and emplace it along with `lvim.ps1`.

## Problem
I didn't find a secure way to set the current user's environment variable in the installer script, using `setx` could be dangerous:

![image](https://github.com/LunarVim/LunarVim/assets/15688641/1dcb6bc5-ca85-4d5f-aabb-1bfa8620bd1c)

the first time I tried in my cmd it overridden my %PATH%, %PATH% in the cmd includes both the system environment variable and user environment variable, and it somehow happens to truncate to 1024 characters.

so for now user has to manually add an environment variable, I am seeking a secure method to add a user environment variable.

## How Has This Been Tested?
1. add `%USERPROFILE%\.local\bin\` to user environment variables
2. run `lvim` normally in cmd.exe

![image](https://github.com/LunarVim/LunarVim/assets/15688641/80a66d1e-aa5e-4c9b-8e15-ddd4e5deff8a)
