### PR TITLE
chore(plugin): update indent-blankline to 3.6.2

### DIFF
--- a/lua/lvim/core/indentlines.lua
+++ b/lua/lvim/core/indentlines.lua
@@ -6,29 +6,26 @@ M.config = function()
     on_config_done = nil,
     options = {
       enabled = true,
-      buftype_exclude = { "terminal", "nofile" },
-      filetype_exclude = {
-        "help",
-        "startify",
-        "dashboard",
-        "lazy",
-        "neogitstatus",
-        "NvimTree",
-        "Trouble",
-        "text",
+      exclude = {
+        buftypes = { "terminal", "nofile" },
+        filetypes = {
+          "help",
+          "startify",
+          "dashboard",
+          "lazy",
+          "neogitstatus",
+          "NvimTree",
+          "Trouble",
+          "text",
+        },
       },
-      char = lvim.icons.ui.LineLeft,
-      context_char = lvim.icons.ui.LineLeft,
-      show_trailing_blankline_indent = false,
-      show_first_indent_level = true,
-      use_treesitter = true,
-      show_current_context = true,
+      indent = { char = lvim.icons.ui.LineLeft },
     },
   }
 end
 
 M.setup = function()
-  local status_ok, indent_blankline = pcall(require, "indent_blankline")
+  local status_ok, indent_blankline = pcall(require, "ibl")
   if not status_ok then
     return
   end

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -325,6 +325,7 @@ local core_plugins = {
 
   {
     "lukas-reineke/indent-blankline.nvim",
+    main = "ibl",
     config = function()
       require("lvim.core.indentlines").setup()
     end,

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -36,7 +36,7 @@
     "commit": "805610a"
   },
   "indent-blankline.nvim": {
-    "commit": "9637670"
+    "commit": "d98f537"
   },
   "lazy.nvim": {
     "commit": "8f19915"


### PR DESCRIPTION
Update [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) plugin to latest version - 3.6.2

Current major version 2 got a bug which lead to some characters not beeing rendered while in the start of new indented line when 'tabstop' and 'shiftwidth' parameters are not the same.

Fixes #4574.