### PR TITLE
feat(plugin): replace neodev with lazydev

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -276,6 +276,7 @@ M.config = function()
       { name = "treesitter" },
       { name = "crates" },
       { name = "tmux" },
+      { name = "lazydev", group_index = 0 },
     },
     mapping = cmp_mapping.preset.insert {
       ["<C-k>"] = cmp_mapping(cmp_mapping.select_prev_item(), { "i", "c" }),

--- a/lua/lvim/lsp/providers/lua_ls.lua
+++ b/lua/lvim/lsp/providers/lua_ls.lua
@@ -2,8 +2,8 @@ local default_workspace = {
   library = {
     "${3rd}/busted/library",
     "${3rd}/luassert/library",
+    "${3rd}/luv/library",
   },
-  checkThirdParty = false,
   maxPreload = 5000,
   preloadFileSize = 10000,
 }

--- a/lua/lvim/lsp/providers/lua_ls.lua
+++ b/lua/lvim/lsp/providers/lua_ls.lua
@@ -1,13 +1,9 @@
 local default_workspace = {
   library = {
-    vim.fn.expand "$VIMRUNTIME",
-    get_lvim_base_dir(),
-    require("neodev.config").types(),
     "${3rd}/busted/library",
     "${3rd}/luassert/library",
-    "${3rd}/luv/library",
   },
-
+  checkThirdParty = false,
   maxPreload = 5000,
   preloadFileSize = 10000,
 }

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -112,13 +112,7 @@ local core_plugins = {
   {
     "folke/lazydev.nvim",
     ft = "lua",
-    opts = {
-      library = {
-        { path = "luvit-meta/library", words = { "vim%.uv" } },
-      },
-    },
   },
-  { "Bilal2453/luvit-meta", lazy = true },
 
   -- Autopairs
   {

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -110,9 +110,15 @@ local core_plugins = {
   },
   { "rafamadriz/friendly-snippets", lazy = true, cond = lvim.builtin.luasnip.sources.friendly_snippets },
   {
-    "folke/neodev.nvim",
-    lazy = true,
+    "folke/lazydev.nvim",
+    ft = "lua",
+    opts = {
+      library = {
+        { path = "luvit-meta/library", words = { "vim%.uv" } },
+      },
+    },
   },
+  { "Bilal2453/luvit-meta", lazy = true },
 
   -- Autopairs
   {

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -56,8 +56,8 @@
   "mason.nvim": {
     "commit": "49ff59a"
   },
-  "neodev.nvim": {
-    "commit": "ce9a2e8"
+  "lazydev.nvim": {
+    "commit": "78d8a11"
   },
   "nlsp-settings.nvim": {
     "commit": "d92035e"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Neodev is now EOL. It is recommended to use [Lazydev](https://github.com/folke/lazydev.nvim) for nvim >= 0.10. Lazydev automatically configures lua_ls for the runtime and plugin directories.

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:LazyDev` and check the `workspace.library` setting to see plugins loaded in the workspace
- Insert `require("busted")` and see the completion for the libray in the lua_ls 3rd folder
- Insert `vim.` and see completion for nvim apis
- Check logs


