### PR TITLE
fix(autocmds): resume view on current tab after _auto_resize

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -71,7 +71,11 @@ function M.load_defaults()
       {
         group = "_auto_resize",
         pattern = "*",
-        command = "tabdo wincmd =",
+        command = [[
+          let _auto_resize_current_tab = tabpagenr()
+          tabdo wincmd =
+          execute 'tabnext' _auto_resize_current_tab
+        ]],
       },
     },
     {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

autocmd _auto_resize now keeps view on current tab

fixes #3007 

## How Has This Been Tested?
Added this to my local installation:

```lua
-- Change autocmd resize
local auto_resize_group = vim.api.nvim_create_augroup('_auto_resize', { clear = true })
vim.api.nvim_create_autocmd({"VimResized"}, {
        group = auto_resize_group,
        pattern = "*",
        command = [[
          let _auto_resize_current_tab = tabpagenr()
          tabdo wincmd =
          execute 'tabnext' _auto_resize_current_tab
        ]],
      })
```

Then two tabs + two splits on each, checking the resize of splits is there, and that we stay on first tab when resizing there: ok

# Notes

Should be matching guidelines except branch name, let me know if you want me to change it. I'll check the guideline beforehand next time

The `install` checks are rather flaky, I had to rerun them twice (2 separate jobs failing), and github doesn't make it easy to rerun them