### PR TITLE
fix(null-ls): avoid linter provider setup multiple times 

### DIFF
--- a/lua/lvim/lsp/null-ls/services.lua
+++ b/lua/lvim/lsp/null-ls/services.lua
@@ -11,7 +11,7 @@ local function find_root_dir()
     return ts_client.config.root_dir
   end
   local dirname = vim.fn.expand "%:p:h"
-  return util.root_pattern "package.json" (dirname)
+  return util.root_pattern "package.json"(dirname)
 end
 
 local function from_node_modules(command)

--- a/lua/lvim/lsp/null-ls/services.lua
+++ b/lua/lvim/lsp/null-ls/services.lua
@@ -11,7 +11,7 @@ local function find_root_dir()
     return ts_client.config.root_dir
   end
   local dirname = vim.fn.expand "%:p:h"
-  return util.root_pattern "package.json"(dirname)
+  return util.root_pattern "package.json" (dirname)
 end
 
 local function from_node_modules(command)
@@ -67,30 +67,36 @@ function M.register_sources(configs, method)
 
   local sources, registered_names = {}, {}
 
+
   for _, config in ipairs(configs) do
     local cmd = config.exe or config.command
     local name = config.name or cmd:gsub("-", "_")
     local type = method == null_ls.methods.CODE_ACTION and "code_actions" or null_ls.methods[method]:lower()
     local source = type and null_ls.builtins[type][name]
     Log:debug(string.format("Received request to register [%s] as a %s source", name, type))
+
+    local command = M.find_command(source._opts.command) or source._opts.command
+
+    -- treat `args` as `extra_args` for backwards compatibility. Can otherwise use `generator_opts.args`
+    local compat_opts = vim.deepcopy(config)
+    if config.args then
+      compat_opts.extra_args = config.args or config.extra_args
+      compat_opts.args = nil
+    end
+
+    local opts = vim.tbl_deep_extend("keep", { command = command }, compat_opts)
+    Log:trace(vim.inspect(opts))
+    source = source.with(opts)
+
+    method = source.method
+
     if not source then
       Log:error("Not a valid source: " .. name)
     elseif is_registered { name = source.name or name, method = method } then
       Log:trace(string.format("Skipping registering [%s] more than once", name))
     else
-      local command = M.find_command(source._opts.command) or source._opts.command
-
-      -- treat `args` as `extra_args` for backwards compatibility. Can otherwise use `generator_opts.args`
-      local compat_opts = vim.deepcopy(config)
-      if config.args then
-        compat_opts.extra_args = config.args or config.extra_args
-        compat_opts.args = nil
-      end
-
-      local opts = vim.tbl_deep_extend("keep", { command = command }, compat_opts)
       Log:debug("Registering source " .. name)
-      Log:trace(vim.inspect(opts))
-      table.insert(sources, source.with(opts))
+      table.insert(sources, source)
       vim.list_extend(registered_names, { source.name })
     end
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
setup null-ls linter provider for golang via Lazy-loading:
after/ftplugin/go.lua
local linters = require("lvim.lsp.null-ls.linters")
linters.setup({
  { name = "golangci_lint" },
})
After open multiple go source files, check the status using command :NullLsInfo, the active source(s) include multiple instances of golangci_lint.

The bug occurs:
In the lvim/lsp/null-ls/linters.lua
local method = null_ls.methods.DIAGNOSTICS
local registered = services.register_sources(linter_configs, method)

The definition of M.register_sources(configs, method) in lvim/lsp/null-ls/services.lua file, 
 The source is registered by null_ls.register { sources = sources } has default field source.method = "DIAGNOSTICS_ON_SAVE "
 while checking whether the source has been registered or not with the arguments: name and method (DIAGNOSTICS)
 is_registered { name = source.name or name, method = method }
 will always return false, so the linter source will be registered repeatedly. 

So the solution is that calling is_registered { name = source.name or name, method = method } using the value of 'source.method' as the method parameter.

summary of the change
 before calling is_registered assign the right value for the 'method' parameter.

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:mycommand`
- Check logs
- ...

